### PR TITLE
Add support for compilation and use on UT-TACC's Stampede3.

### DIFF
--- a/etc/lmp/etc/Makefile.mpi_chimes.UT-TACC
+++ b/etc/lmp/etc/Makefile.mpi_chimes.UT-TACC
@@ -1,0 +1,120 @@
+# mpi = MPI with its default compiler
+
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# compiler/linker settings
+# specify flags and libraries needed for your compiler
+
+CC         = mpiicpc
+CCFLAGS =	-O3 -std=c++11 # -restrict
+SHFLAGS =	-fPIC
+DEPFLAGS =	-M
+
+LINK       = mpiicpc
+LINKFLAGS =	-O3  -std=c++11
+LIB = 
+SIZE =		size
+
+ARCHIVE =	ar
+ARFLAGS =	-rc
+SHLIBFLAGS =	-shared
+
+# ---------------------------------------------------------------------
+# LAMMPS-specific settings, all OPTIONAL
+# specify settings for LAMMPS features you will use
+# if you change any -D setting, do full re-compile after "make clean"
+
+# LAMMPS ifdef settings
+# see possible settings in Section 3.5 of the manual
+
+LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
+
+# MPI library
+# see discussion in Section 3.4 of the manual
+# MPI wrapper compiler/linker can provide this info
+# can point to dummy MPI library in src/STUBS as in Makefile.serial
+# use -D MPICH and OMPI settings in INC to avoid C++ lib conflicts
+# INC = path for mpi.h, MPI compiler settings
+# PATH = path for MPI library
+# LIB = name of MPI library
+
+
+MPI_INC     = -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I${I_MPI_ROOT}/include
+MPI_PATH    = -L${I_MPI_ROOT}/lib -L${I_MPI_ROOT}/lib/release
+MPI_LIB =	
+
+# FFT library
+# see discussion in Section 3.5.2 of manual
+# can be left blank to use provided KISS FFT library
+# INC = -DFFT setting, e.g. -DFFT_FFTW, FFT compiler settings
+# PATH = path for FFT library
+# LIB = name of FFT library
+
+FFT_INC =    	
+FFT_PATH = 
+FFT_LIB =	
+
+# JPEG and/or PNG library
+# see discussion in Section 3.5.4 of manual
+# only needed if -DLAMMPS_JPEG or -DLAMMPS_PNG listed with LMP_INC
+# INC = path(s) for jpeglib.h and/or png.h
+# PATH = path(s) for JPEG library and/or PNG library
+# LIB = name(s) of JPEG library and/or PNG library
+
+JPG_INC =       
+JPG_PATH = 	
+JPG_LIB =	
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# do not edit this section
+
+include	Makefile.package.settings
+include	Makefile.package
+
+EXTRA_INC = $(LMP_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE): main.o $(LMPLIB) $(EXTRA_LINK_DEPENDS)
+	$(LINK) $(LINKFLAGS) main.o $(EXTRA_PATH) $(LMPLINK) $(EXTRA_LIB) $(LIB) -o $@
+	$(SIZE) $@
+
+# Library targets
+
+$(ARLIB): $(OBJ) $(EXTRA_LINK_DEPENDS)
+	@rm -f ../$(ARLIB)
+	$(ARCHIVE) $(ARFLAGS) ../$(ARLIB) $(OBJ)
+	@rm -f $(ARLIB)
+	@ln -s ../$(ARLIB) $(ARLIB)
+
+$(SHLIB): $(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o ../$(SHLIB) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+	@rm -f $(SHLIB)
+	@ln -s ../$(SHLIB) $(SHLIB)
+
+# Compilation rules
+
+%.o:%.cpp
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+# Individual dependencies
+
+depend : fastdep.exe $(SRC)
+	@./fastdep.exe $(EXTRA_INC) -- $^ > .depend || exit 1
+
+fastdep.exe: ../DEPEND/fastdep.c
+	cc -O -o $@ $<
+
+sinclude .depend

--- a/etc/lmp/install.sh
+++ b/etc/lmp/install.sh
@@ -47,6 +47,10 @@ elif [[ "$hosttype" == "JHU-ARCH" ]] ; then
     source modfiles/JHU-ARCH.mod
     ICC=`which icc`
     MPI=`which mpicxx`    
+elif [[ "$hosttype" == "UT-TACC" ]] ; then
+    source modfiles/UT-TACC.mod
+    cp etc/Makefile.mpi_chimes.UT-TACC build/lammps_stable_29Oct2020/src/MAKE/Makefile.mpi_chimes
+
 else
     echo ""
     echo "ERROR: Unknown hosttype ($hosttype) specified"

--- a/etc/lmp/modfiles/UT-TACC.mod
+++ b/etc/lmp/modfiles/UT-TACC.mod
@@ -1,0 +1,3 @@
+module load intel/24.0
+module load impi/21.11
+module load cmake/3.28.1

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,9 @@ elif [[ "$hosttype" == "UM-ARC" ]] ; then
 elif [[ "$hosttype" == "JHU-ARCH" ]] ; then
     source modfiles/JHU-ARCH.mod
     ICC=`which icc`
-    MPI=`which mpicxx`    
+    MPI=`which mpicxx`   
+elif [[ "$hosttype" == "UT-TACC" ]] ; then
+    source modfiles/UT-TACC.mod	
 else
     echo ""
     echo "ERROR: Unknown hosttype ($hosttype) specified"

--- a/modfiles/UT-TACC.mod
+++ b/modfiles/UT-TACC.mod
@@ -1,0 +1,3 @@
+module load intel/24.0
+module load impi/21.11
+module load cmake/3.28.1


### PR DESCRIPTION
- Adds modfiles for chimes_calculator and lmp (UT-TACC.mod)
- Adds a special lmp Makefile for Stampede3
- Updates install scripts (chimes_calculator & lmp) to make use of new modfiles/Makefile

When compiling the chimes_calculator (./) or lmp (./etc/lmp) on Stampede3, use: export hosttype=UT-TACC; ./install.sh

## Items to be completed prior to PR review
# Note: If not completed, submit as a draft PR

- [x] Requested `develop` as target branch
- [x] Attached test suite log file
- [x] Alerted reviewers if edits impact CMake or Makefile files

[run_tests-SHORT-TACC.log](https://github.com/LindseyLab-umich/chimes_calculator-LLfork/files/14899072/run_tests-SHORT-TACC.log)