### PR TITLE
Begin adding support for 3b tabulation

### DIFF
--- a/chimesFF/src/chimesFF.h
+++ b/chimesFF/src/chimesFF.h
@@ -180,18 +180,38 @@ public:
     inline void reset_badness();
     
     
-    // New for tabulation
+    // New for tabulation -- 2b
 
     bool                    tabulate_2B;        
     vector<string>          tab_param_files;    // tab_param_files[pair type index]
     vector<vector<double> > tab_r;              // tab_r[pair type index][rij]
     vector<vector<double> > tab_e;              // tab_e[pair type index][energy]
-    vector<vector<double> > tab_f;              // tab_e[pair type index][force]
+    vector<vector<double> > tab_f;              // tab_f[pair type index][force]
     
     void   read_2B_tab(string tab_file, bool energy=true);
     void   compute_2B_tab(const double dx, const vector<double> & dr, const vector<int> typ_idxs, vector<double> & force, vector<double> & stress, double & energy, chimes2BTmp &tmp, double & force_scalar_in);     
     double get_tab_2B(int pair_idx, double rij, bool for_energy);
     
+    
+    // New for tabulation -- 3b
+    
+    bool                    tabulate_3B;        
+    vector<string>          tab_param_files_3B;     // tab_param_files[trip type index]
+    vector<vector<double> > tab_rij_3B;             // tab_rij_3B[pair type index][rij]
+    vector<vector<double> > tab_rik_3B;             // tab_rik_3B[pair type index][rik]
+    vector<vector<double> > tab_rjk_3B;             // tab_rjk_3B[pair type index][rjk]
+    vector<vector<double> > tab_e_3B;               // tab_e_3B[pair type index][energy]
+    vector<vector<double> > tab_f_ij_3B;             // tab_f_ij_3B[pair type index][force ij]
+    vector<vector<double> > tab_f_ik_3B;             // tab_f_ik_3B[pair type index][force ik]
+    vector<vector<double> > tab_f_jk_3B;             // tab_f_jk_3B[pair type index][force jk]
+    
+    // FUNCTIONS WRITTEN BUT NOT YET TESTED:
+    double interpolateTricubic(int tripidx, double rij, double rik, double rjk, const vector<double>& y);
+    void   read_3B_tab(string tab_file, bool energy=true);
+    void   compute_3B_tab(const vector<double> & dx, const vector<double> & dr, const vector<int> & typ_idxs, vector<double> & force, vector<double> & stress, double & energy, chimes3BTmp &tmp, vector<double> & force_scalar_in);     
+    double get_tab_3B(int tripidx, string pairtyp_ij, string pairtyp_ik, string pairtyp_jk, double rij, double rik, double rjk);
+    double get_tab_3B(int tripidx, string pairtyp_ij, string pairtyp_ik, string pairtyp_jk, double rij, double rik, double rjk, double (&force_scalar)[3]);
+    double get_tab_3B_general(int tripidx, string pairtyp_ij, string pairtyp_ik, string pairtyp_jk, double rij, double rik, double rjk, bool for_energy, double (&force_scalar)[3]);
     
     
 private:


### PR DESCRIPTION
Add partial support for 3b tabulation.

I recommend reading the previous two commit messages for the 2b tabulation capability first.

Capability to read and calculate force/energy/stress has been added, but not ability to generate
the tabulated 3b file/parameter file. Calculation capability is also untested. Lots of work to be done still.

See the read_3B_tab and first two comment blocks of compute_3B_tab for information on expected format of the parameter and tabulated files.

The PES generator/tabulator.py need to be extended for 3b interactions. Testing is needed to determine optimal tabulation density. 

Still needs equivalent of tabulate_2B introduced into class and read_3B_tab.

The 2b capability is implemented into the serial calculator for testing - integration for 3b is needed as well. 

More rigorous testing of *both* the 2- and 3-b tabulated capabilities are needed.