### PR TITLE
Updated module versions for intel and impi

### DIFF
--- a/etc/lmp/modfiles/UM-ARC.mod
+++ b/etc/lmp/modfiles/UM-ARC.mod
@@ -1,3 +1,3 @@
-module load cmake/3.22.2  
-module load intel/18.0.5
-module load impi/2018.4.274
+module load cmake/3.22.2
+module load intel/2022.1.2
+module load impi/2021.5.1


### PR DESCRIPTION
- Updated intel module from 18.0.5 to 2022.1.2
- Updated impi module from 2018.4.274 to 2021.5.1

## Items to be completed prior to PR review
# Note: If not completed, submit as a draft PR

- [N/A] Requested `develop` as target branch
- [N/A] Attached test suite log file
- [✔️] Alerted reviewers if edits impact CMake or Makefile files
